### PR TITLE
Fix cif import symops block detection

### DIFF
--- a/pcf_lib/cif_import.py
+++ b/pcf_lib/cif_import.py
@@ -13,6 +13,8 @@ class CifFile:
 		lines = f.readlines()
 		f.close()
 		i=0
+		sites = []
+		symops = []
 		while i < len(lines):
 			line = lines[i]
 
@@ -36,7 +38,6 @@ class CifFile:
 				print("Importing atoms")
 				i+=1
 				line = lines[i]
-				sites = []
 				jj = 0   # index for keeping track of labels
 				while (line != " \r\n" and line != "\r\n" and line !='\n' 
 						and line !=' \n' and line !='loop_\n' and not line.startswith('#')): #loop until we hit a blank spot
@@ -79,7 +80,6 @@ class CifFile:
 					(("_space_group_symop_operation_xyz" in lines[i+1]
 							or "_symmetry_equiv_pos_site_id" in lines[i+1])
 							or "_symmetry_equiv_pos_as_xyz" in lines[i+1])):
-				symops = []
 				while ('_' in line):  #jump ahead to where the symops are
 					i+=1
 					line = lines[i]
@@ -354,3 +354,4 @@ class CifFile:
 #YbTiO.MultipleScattering(ei=1.0, threshold=0.1, peak = [0,0,2], xcut=np.array([1,1,1]), ycut = np.array([1,1,-2]))
 #print(' ')
 #YbTiO.MultipleScattering(ei=5, threshold=0.1, peak = [-4,2,2], xcut=np.array([1,-1,0]), ycut = np.array([1,1,-2]))
+	

--- a/pcf_lib/cif_import.py
+++ b/pcf_lib/cif_import.py
@@ -90,6 +90,17 @@ class CifFile:
 					line = lines[i]
 				i -= 1
 			i+=1
+			
+		if not sites:
+			# sites list is empty
+			# Without any atoms we can't do anything so this is a fatal error.
+			raise RuntimeError("No atomic sites were found when importing cif file")
+
+		if not symops:
+			# symops list is empy
+			# It may be that we don't have any symops (a supercell perhaps) so this is
+			# a warning rather than an error.
+			raise RuntimeWarning("No symmetry operations were found in the cif file")
 
 		self.asymunitcell = list(sites)
 		# Operate on asymmetric unit cell with all symops and then eliminate duplicates

--- a/pcf_lib/cif_import.py
+++ b/pcf_lib/cif_import.py
@@ -77,7 +77,8 @@ class CifFile:
 
 			# Find the symmetry operations
 			elif (line.startswith("loop_") and 
-					(("_space_group_symop_operation_xyz" in lines[i+1]
+					(("_space_group_symop_id" in lines[i+1]
+							or "_space_group_symop_operation_xyz" in lines[i+1]
 							or "_symmetry_equiv_pos_site_id" in lines[i+1])
 							or "_symmetry_equiv_pos_as_xyz" in lines[i+1])):
 				while ('_' in line):  #jump ahead to where the symops are


### PR DESCRIPTION
I had a couple of issues importing a cif file [example_cif.zip](https://github.com/asche1/PyCrystalField/files/5642167/example_cif.zip) and tracked it down another key that needs to be searched for ("_space_group_symop_id") in the symmetry block detection.

I also made the import just a little more robust by:
1. Ensuring empty lists are always created from sites and symops because they will be used to initialise self after parsing the lines.
2. Raising an error if no sites are found. I think this should be fatal.
3. Raising a warning if no symops are found. I guess it's possible that this is not an error in some use cases so I think a warning is appropriate.
